### PR TITLE
Fix serverside crash when no grave location was found

### DIFF
--- a/src/main/java/de/maxhenkel/gravestone/util/Tools.java
+++ b/src/main/java/de/maxhenkel/gravestone/util/Tools.java
@@ -28,7 +28,7 @@ import net.minecraftforge.common.DimensionManager;
 public class Tools {
 
 	public static String translate(String str, Object... args) {
-		return new ChatComponentTranslation(str, args).getFormattedText();
+		return new ChatComponentTranslation(str, args).getUnformattedTextForChat();
 	}
 
 	public static String dimIDToString(int id) {


### PR DESCRIPTION
The server would previously crash if no gravestone location was found as the method used for translating the message was clientside only (tested on Crucible 1.7.10 server)